### PR TITLE
Fix/enlever greenscore analyse

### DIFF
--- a/Plugin/src/background.js
+++ b/Plugin/src/background.js
@@ -28,6 +28,20 @@ function getTabData(tabId) {
   return tabNetworkData.get(tabId);
 }
 
+function isLocalDomain(url) {
+  try {
+    const hostname = new URL(url).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]"
+    );
+  } catch (error) {
+    console.error("Erreur lors de la vérification du domaine :", error);
+    return false;
+  }
+}
+
 // Récupérer l'intensité carbone pour un pays
 async function getLatestCarbonIntensity(countryCode) {
   try {
@@ -176,29 +190,21 @@ async function processAndSendData(tabId, tabData, isFinal = false) {
     return;
   }
 
-  sendInProgress = true; // Active le verrou
+  // Si l'URL est locale, ne calculez rien
+  if (isLocalDomain(tabData.currentUrl)) {
+    console.log("Données réseau et calculs ignorés : URL en localhost.");
+    return;
+  }
+
+  sendInProgress = true;
 
   try {
-    // Récupère les données utilisateur
     const { isLoggedIn, userId } = await getUserData();
-    console.log(isLoggedIn, userId);
     if (!isLoggedIn || !userId) {
-      return; // Abandonne si l'utilisateur n'est pas connecté
+      return;
     }
 
-    // Prépare les données à envoyer
     const domain = extractDomain(tabData.currentUrl);
-    if (
-      domain === "localhost" ||
-      domain === "127.0.0.1" ||
-      domain === "[::1]"
-    ) {
-      console.log(
-        "Données non calculées/envoyées : URL en localhost ou domaine local."
-      );
-      return; // Interrompt le traitement si l'URL est locale
-    }
-
     const carbonIntensity = tabData.countryCode
       ? await getLatestCarbonIntensity(tabData.countryCode)
       : -1;
@@ -220,13 +226,12 @@ async function processAndSendData(tabId, tabData, isFinal = false) {
       isFinal,
     };
 
-    // Envoie les données
     await sendDataToServer(dataToSend);
-    lastSendTime = now; // Mise à jour du temps du dernier envoi
+    lastSendTime = now;
   } catch (error) {
     console.error("Erreur dans processAndSendData:", error);
   } finally {
-    sendInProgress = false; // Libère le verrou
+    sendInProgress = false;
   }
 }
 
@@ -325,7 +330,7 @@ async function fetchCountry() {
 // Listener pour le début des requêtes
 browser.webRequest.onBeforeRequest.addListener(
   (details) => {
-    if (details.tabId === -1) return; // Ignore les requêtes non associées à un onglet
+    if (details.tabId === -1 || isLocalDomain(details.url)) return; // Ignore les requêtes locales
 
     const tabData = getTabData(details.tabId);
     tabData.totalRequests++;
@@ -346,14 +351,13 @@ browser.webRequest.onBeforeRequest.addListener(
 // Listener pour les headers de réponse
 browser.webRequest.onHeadersReceived.addListener(
   (details) => {
-    if (details.tabId === -1) return;
+    if (details.tabId === -1 || isLocalDomain(details.url)) return;
 
     const tabData = getTabData(details.tabId);
     const requestData = tabData.requestSizes.get(details.requestId);
 
     if (!requestData) return;
 
-    // Récupère la taille du contenu depuis les headers
     const contentLength = details.responseHeaders?.find(
       (header) => header.name.toLowerCase() === "content-length"
     );
@@ -365,7 +369,6 @@ browser.webRequest.onHeadersReceived.addListener(
       }
     }
 
-    // Détermine le type de compression
     const contentEncoding = details.responseHeaders?.find(
       (header) => header.name.toLowerCase() === "content-encoding"
     );
@@ -381,41 +384,36 @@ browser.webRequest.onHeadersReceived.addListener(
 // Listener pour la fin des requêtes
 browser.webRequest.onCompleted.addListener(
   (details) => {
-    if (details.tabId === -1) return;
+    if (details.tabId === -1 || isLocalDomain(details.url)) return;
 
     const tabData = getTabData(details.tabId);
     const requestData = tabData.requestSizes.get(details.requestId);
 
     if (!requestData) return;
 
-    // Met à jour le timestamp de fin
     tabData.endTime = details.timeStamp;
 
-    // Calcule la taille transférée réelle
     let transferredSize = details.responseSize || 0;
     requestData.transferredSize = transferredSize;
 
-    // Calcule la taille réelle de la ressource en fonction de la compression
     let resourceSize = requestData.resourceSize;
     if (transferredSize > 0 && !resourceSize) {
       switch (requestData.encoding) {
         case "gzip":
         case "deflate":
-          resourceSize = transferredSize * 3; // Ratio de compression moyen de 3:1
+          resourceSize = transferredSize * 3;
           break;
         case "br":
-          resourceSize = transferredSize * 5; // Ratio de compression moyen de 5:1
+          resourceSize = transferredSize * 5;
           break;
         default:
           resourceSize = transferredSize;
       }
     }
 
-    // Met à jour les totaux
     tabData.totalTransferredSize += transferredSize;
     tabData.totalResourceSize += resourceSize;
 
-    // Nettoie les données de cette requête
     tabData.requestSizes.delete(details.requestId);
   },
   { urls: ["<all_urls>"] },
@@ -425,7 +423,7 @@ browser.webRequest.onCompleted.addListener(
 // Listener pour les erreurs
 browser.webRequest.onErrorOccurred.addListener(
   (details) => {
-    if (details.tabId === -1) return;
+    if (details.tabId === -1 || isLocalDomain(details.url)) return;
 
     const tabData = getTabData(details.tabId);
     tabData.requestSizes.delete(details.requestId);
@@ -489,211 +487,230 @@ function calculateCarbonEmissions(tabData) {
 }
 
 browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.type === "getCountryAndUrl") {
-    const handleResponse = (tabUrl) => {
-      fetchCountry()
-        .then(({ country }) => {
-          sendResponse({ country, url: extractDomain(tabUrl) });
+  // Envoyer un message au popup si l'onglet est sur localhost
+  browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+    if (tabs.length > 0) {
+      const activeTab = tabs[0];
+      if (isLocalDomain(activeTab.url)) {
+        // Envoie uniquement le message localhost
+        browser.runtime.sendMessage({
+          type: "localhostDetected",
+          message: "Vous êtes bien arrivé sur notre site ;)",
+        });
+        // Retourne early pour éviter l'exécution du reste du code
+        if (sendResponse) {
+          sendResponse({ localhostDetected: true });
+        }
+        return;
+      }
+    }
+
+    if (message.type === "getCountryAndUrl") {
+      const handleResponse = (tabUrl) => {
+        fetchCountry()
+          .then(({ country }) => {
+            sendResponse({ country, url: extractDomain(tabUrl) });
+          })
+          .catch((error) => {
+            console.error("Erreur lors de la récupération du pays :", error);
+            sendResponse({ country: "Unknown", url: extractDomain(tabUrl) });
+          });
+      };
+
+      if (sender.tab && sender.tab.url) {
+        handleResponse(sender.tab.url);
+        return true;
+      }
+
+      browser.tabs
+        .query({ active: true, currentWindow: true })
+        .then((tabs) => {
+          if (tabs.length > 0 && tabs[0].url) {
+            handleResponse(tabs[0].url);
+          } else {
+            sendResponse({ country: "Unknown", url: "Unknown" });
+          }
         })
         .catch((error) => {
-          console.error("Erreur lors de la récupération du pays :", error);
-          sendResponse({ country: "Unknown", url: extractDomain(tabUrl) });
+          console.error(
+            "Erreur lors de la récupération de l'onglet actif :",
+            error
+          );
+          sendResponse({ country: "Unknown", url: "Unknown" });
         });
-    };
 
-    if (sender.tab && sender.tab.url) {
-      handleResponse(sender.tab.url);
       return true;
     }
 
-    browser.tabs
-      .query({ active: true, currentWindow: true })
-      .then((tabs) => {
-        if (tabs.length > 0 && tabs[0].url) {
-          handleResponse(tabs[0].url);
-        } else {
-          sendResponse({ country: "Unknown", url: "Unknown" });
-        }
-      })
-      .catch((error) => {
-        console.error(
-          "Erreur lors de la récupération de l'onglet actif :",
-          error
-        );
-        sendResponse({ country: "Unknown", url: "Unknown" });
-      });
+    if (message.type === "getgCO2e") {
+      return browser.tabs
+        .query({ active: true, currentWindow: true })
+        .then((tabs) => {
+          if (tabs.length > 0) {
+            const tabId = tabs[0].id;
+            const tabData = getTabData(tabId);
 
-    return true;
-  }
-
-  if (message.type === "getgCO2e") {
-    return browser.tabs
-      .query({ active: true, currentWindow: true })
-      .then((tabs) => {
-        if (tabs.length > 0) {
-          const tabId = tabs[0].id;
-          const tabData = getTabData(tabId);
-
-          // Étape 1 : Assurez-vous que le pays et le code du pays sont récupérés
-          const countryPromise =
-            !tabData.country || !tabData.countryCode
-              ? fetchCountry().then(({ country, countryCode }) => {
-                  tabData.country = country;
-                  tabData.countryCode = countryCode;
-                })
-              : Promise.resolve();
-
-          // Étape 2 : Une fois le pays obtenu, assurez-vous que l'intensité carbone est disponible
-          return countryPromise.then(() => {
-            const intensityPromise =
-              tabData.countryCode && tabData.carbonIntensity <= 0
-                ? getLatestCarbonIntensity(tabData.countryCode).then(
-                    (intensity) => {
-                      tabData.carbonIntensity = intensity;
-                    }
-                  )
+            // Étape 1 : Assurez-vous que le pays et le code du pays sont récupérés
+            const countryPromise =
+              !tabData.country || !tabData.countryCode
+                ? fetchCountry().then(({ country, countryCode }) => {
+                    tabData.country = country;
+                    tabData.countryCode = countryCode;
+                  })
                 : Promise.resolve();
 
-            // Étape 3 : Calcul des émissions après avoir récupéré les données nécessaires
-            return intensityPromise.then(() => {
-              const emissionsData = calculateCarbonEmissions(tabData);
+            // Étape 2 : Une fois le pays obtenu, assurez-vous que l'intensité carbone est disponible
+            return countryPromise.then(() => {
+              const intensityPromise =
+                tabData.countryCode && tabData.carbonIntensity <= 0
+                  ? getLatestCarbonIntensity(tabData.countryCode).then(
+                      (intensity) => {
+                        tabData.carbonIntensity = intensity;
+                      }
+                    )
+                  : Promise.resolve();
 
-              console.log("Détails du calcul des émissions pour le front :", {
-                bytesTransferred: tabData.totalTransferredSize,
-                bytesResources: tabData.totalResourceSize,
-                requests: tabData.totalRequests,
-                loadTime: tabData.endTime - tabData.startTime,
-                carbonIntensity: tabData.carbonIntensity,
-                result: emissionsData,
+              // Étape 3 : Calcul des émissions après avoir récupéré les données nécessaires
+              return intensityPromise.then(() => {
+                const emissionsData = calculateCarbonEmissions(tabData);
+
+                console.log("Détails du calcul des émissions pour le front :", {
+                  bytesTransferred: tabData.totalTransferredSize,
+                  bytesResources: tabData.totalResourceSize,
+                  requests: tabData.totalRequests,
+                  loadTime: tabData.endTime - tabData.startTime,
+                  carbonIntensity: tabData.carbonIntensity,
+                  result: emissionsData,
+                });
+
+                return {
+                  gCO2e: emissionsData.totalEmissions,
+                  breakdown: emissionsData.breakdown,
+                  metrics: emissionsData.metrics, // Inclut les métriques pour analyse
+                };
               });
-
-              return {
-                gCO2e: emissionsData.totalEmissions,
-                breakdown: emissionsData.breakdown,
-                metrics: emissionsData.metrics, // Inclut les métriques pour analyse
-              };
             });
-          });
-        } else {
-          // Aucun onglet actif, envoyer des données par défaut
-          return {
-            gCO2e: 0,
-            breakdown: { transfer: 0, datacenter: 0, requests: 0 },
-            metrics: {
-              energy: { transfer: 0, datacenter: 0, requests: 0, total: 0 },
-              data: {
-                gbTransferred: 0,
-                gbResources: 0,
-                requests: 0,
-                loadTimeMs: 0,
-                carbonIntensity: 0,
+          } else {
+            // Aucun onglet actif, envoyer des données par défaut
+            return {
+              gCO2e: 0,
+              breakdown: { transfer: 0, datacenter: 0, requests: 0 },
+              metrics: {
+                energy: { transfer: 0, datacenter: 0, requests: 0, total: 0 },
+                data: {
+                  gbTransferred: 0,
+                  gbResources: 0,
+                  requests: 0,
+                  loadTimeMs: 0,
+                  carbonIntensity: 0,
+                },
               },
-            },
-          };
-        }
-      })
-      .catch((error) => {
-        console.error("Erreur dans le gestionnaire getgCO2e :", error);
-        return {
-          error:
-            "Une erreur est survenue lors du calcul des émissions de carbone.",
-        };
-      });
-  }
-
-  if (message.type === "getFullDetails") {
-    browser.tabs
-      .query({ active: true, currentWindow: true })
-      .then((tabs) => {
-        if (tabs.length === 0) {
-          sendResponse({ error: "Aucun onglet actif trouvé." });
-          return;
-        }
-
-        const activeTab = tabs[0];
-        const tabId = activeTab.id;
-        const tabData = getTabData(tabId);
-
-        sendResponse({
-          country: tabData.country || "Unknown",
-          countryCode: tabData.countryCode || "Unknown",
-          urlDomain: extractDomain(tabData.currentUrl || activeTab.url),
-          urlFull: tabData.currentUrl || activeTab.url,
-          totalTransferredSize: tabData.totalTransferredSize || 0,
-          totalRequests: tabData.totalRequests || 0,
-          totalResourceSize: tabData.totalResourceSize || 0,
-          loadTime: (tabData.endTime - tabData.startTime) / 1000 || 0,
-        });
-      })
-      .catch((error) => {
-        console.error(
-          "Erreur lors de la récupération de l'onglet actif :",
-          error
-        );
-        sendResponse({ error: error.message });
-      });
-
-    return true;
-  }
-
-  if (message.type === "checkLoginStatus") {
-    return getUserData();
-  }
-
-  if (message.type === "getEquivalent") {
-    browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
-      if (tabs.length === 0) {
-        sendResponse({ success: false, error: "Aucun onglet actif trouvé." });
-        return;
-      }
-
-      const tabId = tabs[0].id;
-      const tabData = getTabData(tabId);
-
-      // Calcul des émissions d'abord
-      const emissions = calculateCarbonEmissions(tabData);
-      const gCO2 = emissions.totalEmissions;
-      const count = message.count || 1;
-
-      // Appel direct à l'API Symfony
-      fetch(
-        `http://127.0.0.1:8000/api/equivalent?gCO2=${gCO2}&count=${count}`,
-        {
-          method: "GET",
-          headers: {
-            "Content-Type": "application/json",
-          },
-        }
-      )
-        .then((response) => {
-          if (!response.ok) {
-            throw new Error(`Erreur API Symfony : ${response.status}`);
+            };
           }
-          return response.json();
         })
-        .then((equivalents) => {
-          console.log("Équivalents reçus :", equivalents);
+        .catch((error) => {
+          console.error("Erreur dans le gestionnaire getgCO2e :", error);
+          return {
+            error:
+              "Une erreur est survenue lors du calcul des émissions de carbone.",
+          };
+        });
+    }
+
+    if (message.type === "getFullDetails") {
+      browser.tabs
+        .query({ active: true, currentWindow: true })
+        .then((tabs) => {
+          if (tabs.length === 0) {
+            sendResponse({ error: "Aucun onglet actif trouvé." });
+            return;
+          }
+
+          const activeTab = tabs[0];
+          const tabId = activeTab.id;
+          const tabData = getTabData(tabId);
+
           sendResponse({
-            success: true,
-            equivalents: equivalents.map((eq) => ({
-              image:
-                "https://greenscoreweb.alwaysdata.net/public/equivalents/" +
-                  eq.icon || "../assets/images/account.svg",
-              value: eq.value,
-              name: eq.name,
-            })),
+            country: tabData.country || "Unknown",
+            countryCode: tabData.countryCode || "Unknown",
+            urlDomain: extractDomain(tabData.currentUrl || activeTab.url),
+            urlFull: tabData.currentUrl || activeTab.url,
+            totalTransferredSize: tabData.totalTransferredSize || 0,
+            totalRequests: tabData.totalRequests || 0,
+            totalResourceSize: tabData.totalResourceSize || 0,
+            loadTime: (tabData.endTime - tabData.startTime) / 1000 || 0,
           });
         })
         .catch((error) => {
-          console.error("Erreur dans getEquivalent:", error);
-          sendResponse({
-            success: false,
-            error: error.message,
-          });
+          console.error(
+            "Erreur lors de la récupération de l'onglet actif :",
+            error
+          );
+          sendResponse({ error: error.message });
         });
-    });
 
-    // Important: retourner true pour indiquer que sendResponse sera appelé de manière asynchrone
-    return true;
-  }
+      return true;
+    }
+
+    if (message.type === "checkLoginStatus") {
+      return getUserData();
+    }
+
+    if (message.type === "getEquivalent") {
+      browser.tabs.query({ active: true, currentWindow: true }).then((tabs) => {
+        if (tabs.length === 0) {
+          sendResponse({ success: false, error: "Aucun onglet actif trouvé." });
+          return;
+        }
+
+        const tabId = tabs[0].id;
+        const tabData = getTabData(tabId);
+
+        // Calcul des émissions d'abord
+        const emissions = calculateCarbonEmissions(tabData);
+        const gCO2 = emissions.totalEmissions;
+        const count = message.count || 1;
+
+        // Appel direct à l'API Symfony
+        fetch(
+          `http://127.0.0.1:8000/api/equivalent?gCO2=${gCO2}&count=${count}`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          }
+        )
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`Erreur API Symfony : ${response.status}`);
+            }
+            return response.json();
+          })
+          .then((equivalents) => {
+            console.log("Équivalents reçus :", equivalents);
+            sendResponse({
+              success: true,
+              equivalents: equivalents.map((eq) => ({
+                image:
+                  "https://greenscoreweb.alwaysdata.net/public/equivalents/" +
+                    eq.icon || "../assets/images/account.svg",
+                value: eq.value,
+                name: eq.name,
+              })),
+            });
+          })
+          .catch((error) => {
+            console.error("Erreur dans getEquivalent:", error);
+            sendResponse({
+              success: false,
+              error: error.message,
+            });
+          });
+      });
+
+      // Important: retourner true pour indiquer que sendResponse sera appelé de manière asynchrone
+      return true;
+    }
+  });
 });

--- a/Plugin/src/popup.html
+++ b/Plugin/src/popup.html
@@ -1,88 +1,137 @@
 <!DOCTYPE html>
 <html lang="fr">
-<head>
-    <meta charset="UTF-8">
+  <head>
+    <meta charset="UTF-8" />
     <title>Popup</title>
-    <script src="https://kit.fontawesome.com/5fbdf29340.js" crossorigin="anonymous"></script>
-    <link href="./popup.css" rel="stylesheet">
+    <script
+      src="https://kit.fontawesome.com/5fbdf29340.js"
+      crossorigin="anonymous"
+    ></script>
+    <link href="./popup.css" rel="stylesheet" />
     <script src="popup.js" defer></script>
-</head>
+  </head>
 
-<body class="w-[440px] pb-4">
-    <header class="px-8 py-3 flex justify-between items-center border-b border-grey-100 h-fit">
-        <div class="flex gap-2 items-center">
-            <img src="../assets/images/logo.png" alt="GreenScore Logo" style="width: 32px; height:34px">
-            <h1 class="text-2xl font-outfit font-extrabold text-gs-green-950">GreenScore Web</h1>
-        </div>
-        <img src="../assets/images/account.svg" alt="Compte" class="cursor-pointer">
+  <body class="w-[440px] pb-4">
+    <header
+      class="px-8 py-3 flex justify-between items-center border-b border-grey-100 h-fit"
+    >
+      <div class="flex gap-2 items-center">
+        <img
+          src="../assets/images/logo.png"
+          alt="GreenScore Logo"
+          style="width: 32px; height: 34px"
+        />
+        <h1 class="text-2xl font-outfit font-extrabold text-gs-green-950">
+          GreenScore Web
+        </h1>
+      </div>
+      <img
+        src="../assets/images/account.svg"
+        alt="Compte"
+        class="cursor-pointer"
+      />
     </header>
-
-    <div class="flex flex-row font-outfit w-full items-center justify-center p-2">
+    <div id="main-container">
+      <div
+        class="flex flex-row font-outfit w-full items-center justify-center p-2"
+      >
         <p class="text-grey-400 text-sm">Site actuel :&nbsp</p>
         <p id="site-url" class="text-grey-400 text-sm font-bold">*site.fr*</p>
-    </div>
+      </div>
 
-    <div class="flex flex-col gap-6 px-4">
+      <div class="flex flex-col gap-6 px-4">
         <div class="flex flex-col items-center justify-center gap-2 w-full">
-            <h2 id="site-country" class="text-xl w-2/3 text-center font-extrabold font-outfit text-grey-950">
-                Dans votre pays (*Pays*), cette page consomme
-            </h2>
-            <div class="flex flex-col justify-center items-center">
-                <div id="gCO2e-container" class="flex items-baseline font-outfit text-[#BD2525]">
-                    <span id="gCO2e-value" class="text-5xl font-extrabold">0&nbsp;</span>
-                    <div class="flex font-medium gap-0 items-baseline">
-                        <span class="text-base">gC0</span>
-                        <span class="text-xs">2</span>
-                        <span class="text-base">e</span>
-                    </div>
-                </div>
-                <div class="flex font-outfit font-light text-base text-grey-950">
-                    <span>C'est&nbsp;</span>
-                    <span class="font-bold" id="average-consumption">0</span>
-                    <span>&nbsp;à la moyenne !</span>
-                </div>
+          <h2
+            id="site-country"
+            class="text-xl w-2/3 text-center font-extrabold font-outfit text-grey-950"
+          >
+            Dans votre pays (*Pays*), cette page consomme
+          </h2>
+          <div class="flex flex-col justify-center items-center">
+            <div
+              id="gCO2e-container"
+              class="flex items-baseline font-outfit text-[#BD2525]"
+            >
+              <span id="gCO2e-value" class="text-5xl font-extrabold"
+                >0&nbsp;</span
+              >
+              <div class="flex font-medium gap-0 items-baseline">
+                <span class="text-base">gC0</span>
+                <span class="text-xs">2</span>
+                <span class="text-base">e</span>
+              </div>
             </div>
+            <div class="flex font-outfit font-light text-base text-grey-950">
+              <span>C'est&nbsp;</span>
+              <span class="font-bold" id="average-consumption">0</span>
+              <span>&nbsp;à la moyenne !</span>
+            </div>
+          </div>
         </div>
 
         <div class="flex flex-col font-outfit gap-2">
-            <p class="text-sm font-light">Cela correspond à :</p>
-            <div class="flex gap-3 items-center justify-center">
-                <!-- Carte 1 -->
-                <div class="comparison-card flex flex-col p-2 w-[120px] h-[120px] gap-2 rounded-[4px]">
-                    <div class="flex flex-col gap-[6px]">
-                        <img src="../assets/images/account.svg" class="w-5 h-5 object-cover">
-                        <p class="text-xl font-extrabold">0.00</p>
-                    </div>
-                    <p class="text-xs">Pas de données</p>
-                </div>
-                <!-- Carte 2 -->
-                <div class="comparison-card flex flex-col p-2 w-[120px] h-[120px] gap-2 rounded-[4px]">
-                    <div class="flex flex-col gap-[6px]">
-                        <img src="../assets/images/account.svg" class="w-5 h-5 object-cover">
-                        <p class="text-xl font-extrabold">0.00</p>
-                    </div>
-                    <p class="text-xs">Pas de données</p>
-                </div>
-                <!-- Carte 3 -->
-                <div class="comparison-card flex flex-col p-2 w-[120px] h-[120px] gap-2 rounded-[4px]">
-                    <div class="flex flex-col gap-[6px]">
-                        <img src="../assets/images/account.svg" class="w-5 h-5 object-cover">
-                        <p class="text-xl font-extrabold">0.00</p>
-                    </div>
-                    <p class="text-xs">Pas de données</p>
-                </div>
+          <p class="text-sm font-light">Cela correspond à :</p>
+          <div class="flex gap-3 items-center justify-center">
+            <!-- Carte 1 -->
+            <div
+              class="comparison-card flex flex-col p-2 w-[120px] h-[120px] gap-2 rounded-[4px]"
+            >
+              <div class="flex flex-col gap-[6px]">
+                <img
+                  src="../assets/images/account.svg"
+                  class="w-5 h-5 object-cover"
+                />
+                <p class="text-xl font-extrabold">0.00</p>
+              </div>
+              <p class="text-xs">Pas de données</p>
             </div>
+            <!-- Carte 2 -->
+            <div
+              class="comparison-card flex flex-col p-2 w-[120px] h-[120px] gap-2 rounded-[4px]"
+            >
+              <div class="flex flex-col gap-[6px]">
+                <img
+                  src="../assets/images/account.svg"
+                  class="w-5 h-5 object-cover"
+                />
+                <p class="text-xl font-extrabold">0.00</p>
+              </div>
+              <p class="text-xs">Pas de données</p>
+            </div>
+            <!-- Carte 3 -->
+            <div
+              class="comparison-card flex flex-col p-2 w-[120px] h-[120px] gap-2 rounded-[4px]"
+            >
+              <div class="flex flex-col gap-[6px]">
+                <img
+                  src="../assets/images/account.svg"
+                  class="w-5 h-5 object-cover"
+                />
+                <p class="text-xl font-extrabold">0.00</p>
+              </div>
+              <p class="text-xs">Pas de données</p>
+            </div>
+          </div>
         </div>
 
         <div class="flex flex-col w-full gap-2">
-            <a id="details-button" href="#" class="flex justify-center items-center py-2 text-white font-outfit font-medium bg-gs-green-950 rounded-lg w-full h-fit">
-                Plus de détails
-            </a>
-            <div class="flex font-outfit text-sm justify-center">
-                <span class="text-sm text-grey-950">Vous souhaitez enregistrer ce résultat ?&nbsp;</span>
-                <a href="#" class="text-[#6D874B] font-bold underline">Se connecter</a>
-            </div>
+          <a
+            id="details-button"
+            href="#"
+            class="flex justify-center items-center py-2 text-white font-outfit font-medium bg-gs-green-950 rounded-lg w-full h-fit"
+          >
+            Plus de détails
+          </a>
+          <div class="flex font-outfit text-sm justify-center">
+            <span class="text-sm text-grey-950"
+              >Vous souhaitez enregistrer ce résultat ?&nbsp;</span
+            >
+            <a href="#" class="text-[#6D874B] font-bold underline"
+              >Se connecter</a
+            >
+          </div>
         </div>
+      </div>
     </div>
-</body>
+  </body>
 </html>

--- a/Plugin/src/popup.js
+++ b/Plugin/src/popup.js
@@ -35,162 +35,202 @@ async function updateEquivalents() {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
-  function getColorClass(gCO2e) {
-    const value = Number(gCO2e);
+  let isLocalhost = false;
 
-    if (value <= 0.3) {
-      return {
-        text: "text-[#617D3B]",
-        bg: "bg-[#ECFDF2]",
-        border: "border-[#6D874B]",
-      };
-    } else if (value <= 0.7) {
-      return {
-        text: "text-[#EAC13A]",
-        bg: "bg-[#FFF1C5]",
-        border: "border-[#EAC13A]",
-      };
-    } else if (value <= 1) {
-      return {
-        text: "text-[#E98035]",
-        bg: "bg-[#F9D2B6]",
-        border: "border-[#E98035]",
-      };
-    } else {
-      return {
-        text: "text-[#BD2525]",
-        bg: "bg-[#FFB7B7]",
-        border: "border-[#BD2525]",
-      };
+  // Écouteur pour le message localhost
+  browser.runtime.onMessage.addListener((message) => {
+    if (message.type === "localhostDetected") {
+      isLocalhost = true;
+      const mainContainer = document.getElementById("main-container");
+      if (mainContainer) {
+        mainContainer.innerHTML = `
+        <div class="flex flex-col items-center justify-center h-full text-center flex flex-col gap-6 py-4 px-4">
+          <p class="text-3xl font-bold font-outfit">${message.message}</p>
+          <a
+            id="details-button"
+            href="127.0.0.1:8000/#"
+            class="flex justify-center items-center py-2 px-4 text-white font-outfit font-medium bg-gs-green-950 rounded-lg"
+          >
+            Plus d'informations
+          </a>
+        </div>
+`;
+
+        // Ajouter un gestionnaire d'événement pour ouvrir dans un nouvel onglet
+        const detailsButton = document.getElementById("details-button");
+        if (detailsButton) {
+          detailsButton.addEventListener("click", (event) => {
+            event.preventDefault(); // Empêche la navigation par défaut
+            browser.tabs.create({ url: "http://127.0.0.1:8000/#" });
+          });
+        }
+      }
+      return;
     }
-  }
+  });
 
-  function updateColors(gCO2e) {
-    const colorClasses = getColorClass(gCO2e);
+  // Si ce n'est pas localhost, continuer avec le reste des fonctionnalités
+  if (!isLocalhost) {
+    function getColorClass(gCO2e) {
+      const value = Number(gCO2e);
 
-    const gCO2eContainer = document.getElementById("gCO2e-container");
-    const gCO2eValue = document.getElementById("gCO2e-value");
-
-    if (gCO2eContainer && gCO2eValue) {
-      gCO2eContainer.className = `flex items-baseline font-outfit ${colorClasses.text}`;
-      gCO2eValue.textContent = `${gCO2e}\u00A0`;
-    }
-
-    const comparisonCards = document.querySelectorAll(".comparison-card");
-    comparisonCards.forEach((card) => {
-      card.className = `comparison-card flex flex-col p-2 w-[120px] h-[120px] ${colorClasses.bg} ${colorClasses.text} gap-2 border ${colorClasses.border} rounded-[4px]`;
-    });
-  }
-
-  function updateAverageConsumption(gCO2e) {
-    const AVERAGE_CONSUMPTION = 0.74; // Valeur obtenue sur un calcul de moyenne sur plus de 100 sites
-    let multiplier = gCO2e / AVERAGE_CONSUMPTION;
-
-    if (multiplier > 1) {
-      document.getElementById("average-consumption").textContent =
-          `${multiplier.toFixed(2)}x supérieur`;
-    } else {
-      document.getElementById("average-consumption").textContent =
-          `${(1 / multiplier).toFixed(2)}x inférieur`;
-    }
-  }
-
-  // Vérification du statut de connexion
-  try {
-    const userData = await browser.runtime.sendMessage({
-      type: "checkLoginStatus",
-    });
-    const loginSection = document.querySelector(
-      ".flex.font-outfit.text-sm.justify-center"
-    );
-    const detailsButton = document.getElementById("details-button");
-
-    if (loginSection) {
-      if (userData.isLoggedIn) {
-        loginSection.innerHTML =
-          '<span class="text-sm text-grey-950">Vous êtes connecté</span>';
+      if (value <= 0.3) {
+        return {
+          text: "text-[#617D3B]",
+          bg: "bg-[#ECFDF2]",
+          border: "border-[#6D874B]",
+        };
+      } else if (value <= 0.7) {
+        return {
+          text: "text-[#EAC13A]",
+          bg: "bg-[#FFF1C5]",
+          border: "border-[#EAC13A]",
+        };
+      } else if (value <= 1) {
+        return {
+          text: "text-[#E98035]",
+          bg: "bg-[#F9D2B6]",
+          border: "border-[#E98035]",
+        };
       } else {
-        loginSection.innerHTML = `
+        return {
+          text: "text-[#BD2525]",
+          bg: "bg-[#FFB7B7]",
+          border: "border-[#BD2525]",
+        };
+      }
+    }
+
+    function updateColors(gCO2e) {
+      const colorClasses = getColorClass(gCO2e);
+
+      const gCO2eContainer = document.getElementById("gCO2e-container");
+      const gCO2eValue = document.getElementById("gCO2e-value");
+
+      if (gCO2eContainer && gCO2eValue) {
+        gCO2eContainer.className = `flex items-baseline font-outfit ${colorClasses.text}`;
+        gCO2eValue.textContent = `${gCO2e}\u00A0`;
+      }
+
+      const comparisonCards = document.querySelectorAll(".comparison-card");
+      comparisonCards.forEach((card) => {
+        card.className = `comparison-card flex flex-col p-2 w-[120px] h-[120px] ${colorClasses.bg} ${colorClasses.text} gap-2 border ${colorClasses.border} rounded-[4px]`;
+      });
+    }
+
+    function updateAverageConsumption(gCO2e) {
+      const AVERAGE_CONSUMPTION = 0.74; // Valeur obtenue sur un calcul de moyenne sur plus de 100 sites
+      let multiplier = gCO2e / AVERAGE_CONSUMPTION;
+
+      if (multiplier > 1) {
+        document.getElementById(
+          "average-consumption"
+        ).textContent = `${multiplier.toFixed(2)}x supérieur`;
+      } else {
+        document.getElementById("average-consumption").textContent = `${(
+          1 / multiplier
+        ).toFixed(2)}x inférieur`;
+      }
+    }
+
+    // Vérification du statut de connexion
+    try {
+      const userData = await browser.runtime.sendMessage({
+        type: "checkLoginStatus",
+      });
+      const loginSection = document.querySelector(
+        ".flex.font-outfit.text-sm.justify-center"
+      );
+      const detailsButton = document.getElementById("details-button");
+
+      if (loginSection) {
+        if (userData.isLoggedIn) {
+          loginSection.innerHTML =
+            '<span class="text-sm text-grey-950">Vous êtes connecté</span>';
+        } else {
+          loginSection.innerHTML = `
           <span class="text-sm text-grey-950">Vous souhaitez enregistrer ce résultat ?&nbsp;</span>
           <a href="http://127.0.0.1:8000/login" class="text-[#6D874B] font-bold underline">Se connecter</a>
         `;
+        }
       }
-    }
 
-    // Mise à jour des couleurs en fonction de gCO2e
-    try {
-      const response = await browser.runtime.sendMessage({ type: "getgCO2e" });
-      if (response && typeof response.gCO2e === "number") {
-        updateColors(response.gCO2e);
-        updateAverageConsumption(response.gCO2e);
-        gCO2eValue = response.gCO2e;
+      // Mise à jour des couleurs en fonction de gCO2e
+      try {
+        const response = await browser.runtime.sendMessage({
+          type: "getgCO2e",
+        });
+        if (response && typeof response.gCO2e === "number") {
+          updateColors(response.gCO2e);
+          updateAverageConsumption(response.gCO2e);
+          gCO2eValue = response.gCO2e;
+        }
+      } catch (error) {
+        console.error("Erreur lors de la récupération du gCO2e:", error);
+      }
+
+      // Gestion du bouton "Plus de détails"
+      if (detailsButton) {
+        detailsButton.addEventListener("click", async (e) => {
+          e.preventDefault();
+
+          // Récupérer les détails actuels
+          const response = await browser.runtime.sendMessage({
+            type: "getFullDetails",
+          });
+
+          let url = "http://127.0.0.1:8000/derniere-page-web-consultee";
+
+          if (!userData.isLoggedIn) {
+            // Construction des paramètres d'URL si non connecté
+            const params = new URLSearchParams({
+              country: response.country || "",
+              url_full: response.urlFull || "",
+              totalConsu: gCO2eValue || 0,
+              pageSize: response.totalResourceSize || 0,
+              loadingTime: response.loadTime || 0,
+              queriesQuantity: response.totalRequests || 0,
+            });
+            url += "?" + params.toString();
+          }
+
+          // Ouvrir l'URL dans un nouvel onglet
+          window.open(url, "_blank");
+        });
       }
     } catch (error) {
-      console.error("Erreur lors de la récupération du gCO2e:", error);
-    }
-
-    // Gestion du bouton "Plus de détails"
-    if (detailsButton) {
-      detailsButton.addEventListener("click", async (e) => {
-        e.preventDefault();
-
-        // Récupérer les détails actuels
-        const response = await browser.runtime.sendMessage({
-          type: "getFullDetails",
-        });
-
-        let url = "http://127.0.0.1:8000/derniere-page-web-consultee";
-
-        if (!userData.isLoggedIn) {
-          // Construction des paramètres d'URL si non connecté
-          const params = new URLSearchParams({
-            country: response.country || "",
-            url_full: response.urlFull || "",
-            totalConsu: gCO2eValue || 0,
-            pageSize: response.totalResourceSize || 0,
-            loadingTime: response.loadTime || 0,
-            queriesQuantity: response.totalRequests || 0,
-          });
-          url += "?" + params.toString();
-        }
-
-        // Ouvrir l'URL dans un nouvel onglet
-        window.open(url, "_blank");
-      });
-    }
-  } catch (error) {
-    console.error(
-      "Erreur lors de la vérification de l'état de connexion:",
-      error
-    );
-  }
-
-  browser.runtime
-    .sendMessage({ type: "getCountryAndUrl" })
-    .then((response) => {
-      if (response && response.country && response.url) {
-        const urlElement = document.getElementById("site-url");
-        const countryElement = document.getElementById("site-country");
-
-        if (countryElement && urlElement) {
-          countryElement.textContent = `Dans votre pays (${response.country}), cette page consomme`;
-          urlElement.textContent = response.url;
-        }
-      } else if (response.error) {
-        console.error("Erreur :", response.error);
-      }
-    })
-    .catch((error) => {
       console.error(
-        "Erreur lors de la récupération du pays ou de l'URL :",
+        "Erreur lors de la vérification de l'état de connexion:",
         error
       );
-    });
+    }
+
+    browser.runtime
+      .sendMessage({ type: "getCountryAndUrl" })
+      .then((response) => {
+        if (response && response.country && response.url) {
+          const urlElement = document.getElementById("site-url");
+          const countryElement = document.getElementById("site-country");
+
+          if (countryElement && urlElement) {
+            countryElement.textContent = `Dans votre pays (${response.country}), cette page consomme`;
+            urlElement.textContent = response.url;
+          }
+        } else if (response.error) {
+          console.error("Erreur :", response.error);
+        }
+      })
+      .catch((error) => {
+        console.error(
+          "Erreur lors de la récupération du pays ou de l'URL :",
+          error
+        );
+      });
 
     try {
       await updateEquivalents();
     } catch (error) {
       console.error("Erreur lors de la mise à jour des équivalents :", error);
     }
-    
+  }
 });


### PR DESCRIPTION
Permet de faire en sorte que le plugin n'analyse pas notre propre site. Cela laisse un petit message pour aller vers la page d'informations, et n'effectue donc pas l'analyse.